### PR TITLE
Fix async expectations and helpers

### DIFF
--- a/tests/LogInPageUIControls.spec.js
+++ b/tests/LogInPageUIControls.spec.js
@@ -3,57 +3,57 @@ const {openLoginPagePractise, loginWithCredentials} = require('../utils/LoginPag
 const { console } = require('inspector');
 
 test('Login Page Happy Flow', async ({page})=>{
-    openLoginPagePractise(page);
-    loginWithCredentials(page, "rahulshettyacademy", "learning");
+    await openLoginPagePractise(page);
+    await loginWithCredentials(page, "rahulshettyacademy", "learning");
     await page.locator('#terms').click();
     await page.locator('#signInBtn').click();
 })
 
 test('Login with incorrect username', async ({page})=>{
-    openLoginPagePractise(page);
-    loginWithCredentials(page, "rahulshettyacademy1", "learning");
+    await openLoginPagePractise(page);
+    await loginWithCredentials(page, "rahulshettyacademy1", "learning");
     await page.locator('#terms').click();
     await page.locator('#signInBtn').click();
     await expect(page.locator("[style*=block]")).toContainText("Incorrect")
 })
 
 test('Login with incorrect password', async ({page})=>{
-    openLoginPagePractise(page);
-    loginWithCredentials(page, "rahulshettyacademy", "learning1");
+    await openLoginPagePractise(page);
+    await loginWithCredentials(page, "rahulshettyacademy", "learning1");
     await page.locator('#terms').click();
     await expect (page.locator('#terms')).toBeChecked();
     await page.locator('#terms').uncheck()
-    expect (await page.locator('#terms').isChecked).toBeFalsy;
+    expect (await page.locator('#terms').isChecked()).toBeFalsy();
     await page.locator('#signInBtn').click();
     await expect(page.locator("[style*=block]")).toContainText("Incorrect")
 })
 
 test('Log in with Terms and conditions checkbox ticked should be mandatory', async ({page})=>{
-    openLoginPagePractise(page);
-    loginWithCredentials(page, "rahulshettyacademy", "learning");
+    await openLoginPagePractise(page);
+    await loginWithCredentials(page, "rahulshettyacademy", "learning");
     await page.locator('#signInBtn').click();
     await expect(page.locator("[style*=block]")).toContainText("Please indicate that you have read and agree to the Terms and Conditions and Privacy Policy")
 })
 
 test('Login as a user will trigger a popup to be displayed', async ({page})=>{
-    openLoginPagePractise(page);
-    loginWithCredentials(page, "rahulshettyacademy", "learning");
+    await openLoginPagePractise(page);
+    await loginWithCredentials(page, "rahulshettyacademy", "learning");
     await page.locator('#terms').click();
     await page.locator('#usertype').nth(1).click();
-    expect(page.locator('#usertype').nth(1)).toBeChecked();
+    await expect(page.locator('#usertype').nth(1)).toBeChecked();
     await expect(page.locator(".modal-body p")).toContainText("You will be limited");
     await page.locator('#cancelBtn').click();
     await page.locator('#usertype').first().click();
-    expect(page.locator('#usertype').first()).toBeChecked();
+    await expect(page.locator('#usertype').first()).toBeChecked();
     await page.locator('#usertype').nth(1).click();
-    expect(page.locator(".modal-body p")).toContainText("You will be limited");
+    await expect(page.locator(".modal-body p")).toContainText("You will be limited");
     await page.locator('#okayBtn').click();
     await page.locator('#signInBtn').click();   
 })
 
 test('Select options from dropdown', async ({page})=>{
-    openLoginPagePractise(page);
-    loginWithCredentials(page, "rahulshettyacademy", "learning");
+    await openLoginPagePractise(page);
+    await loginWithCredentials(page, "rahulshettyacademy", "learning");
     await page.locator('#terms').click();
     await page.selectOption('select.form-control', "teach") //selectOption('locator', 'optiontoselect')
     await page.selectOption('select.form-control', "consult")
@@ -66,8 +66,8 @@ test('Link text has blicking class and opens in new tab', async ({page})=>{
 
     const documentsLink =  page.locator('[href*="documents-request"]');
     
-    openLoginPagePractise(page);
-    loginWithCredentials(page, "rahulshettyacademy", "learning");
+    await openLoginPagePractise(page);
+    await loginWithCredentials(page, "rahulshettyacademy", "learning");
     await( expect (documentsLink).toHaveAttribute('class', 'blinkingText'));
     await( expect (documentsLink).toHaveClass('blinkingText'));
     
@@ -77,7 +77,7 @@ test('Child window handling test', async ({browser}) =>{
 
     const context = await browser.newContext();
     const page  = await context.newPage()
-    openLoginPagePractise(page);
+    await openLoginPagePractise(page);
 
     const documentsLink =  page.locator('[href*="documents-request"]');
     const [newPage] = await Promise.all([  //[newPage] - const will be an array]

--- a/utils/E2E_eCommerce/userRegistrationAction.js
+++ b/utils/E2E_eCommerce/userRegistrationAction.js
@@ -26,8 +26,8 @@ async function userRegistration (page) {
     await page.locator('#confirmPassword').fill(user.password);
 
     await page.locator('input[type="checkbox"]').click();
-    expect(page.locator('input[type="checkbox"]')).toBeChecked();
-    expect(page.locator('input[type="checkbox"]')).toHaveClass(/ng-valid/); //when element have multiple classes, use regex to match
+    await expect(page.locator('input[type="checkbox"]')).toBeChecked();
+    await expect(page.locator('input[type="checkbox"]')).toHaveClass(/ng-valid/); //when element have multiple classes, use regex to match
     await page.locator('input[type="submit"]').click();
 
     return {


### PR DESCRIPTION
## Summary
- await checkbox expectations in registration helper
- await helper calls in login tests
- fix isChecked usage

## Testing
- `npx playwright test --list` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6876a278b798832c8d877f1a99de8ac8